### PR TITLE
Remove activesupport dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,31 +2,21 @@ PATH
   remote: .
   specs:
     amqp_mailer (0.1.0)
-      activesupport (~> 5.0)
       bunny (>= 2.6.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.5)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     amq-protocol (2.2.0)
     ast (2.4.0)
-    bunny (2.7.2)
-      amq-protocol (>= 2.2.0)
+    bunny (2.7.4)
+      amq-protocol (~> 2.2.0)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
-    i18n (0.9.5)
-      concurrent-ruby (~> 1.0)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
     mini_mime (1.0.0)
-    minitest (5.11.3)
     parallel (1.12.1)
     parser (2.5.0.2)
       ast (~> 2.4.0)
@@ -57,9 +47,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS

--- a/amqp_mailer.gemspec
+++ b/amqp_mailer.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '~> 5.0'
   spec.add_dependency 'bunny', '>= 2.6.3'
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lib/amqp_mailer/utils.rb
+++ b/lib/amqp_mailer/utils.rb
@@ -1,0 +1,8 @@
+module AmqpMailer
+  module Utils
+    def blank?(obj)
+      obj = obj.respond_to?(:strip) ? obj.strip : obj
+      obj.respond_to?(:empty?) ? obj.empty? : !obj
+    end
+  end
+end

--- a/spec/amqp_mailer/amqp_mailer/utils_spec.rb
+++ b/spec/amqp_mailer/amqp_mailer/utils_spec.rb
@@ -1,0 +1,22 @@
+require 'amqp_mailer/utils'
+
+describe AmqpMailer::Utils do
+  describe 'blank?' do
+    include AmqpMailer::Utils
+
+    it 'works with strings' do
+      expect(blank?('')).to eq(true)
+      expect(blank?('    ')).to eq(true)
+      expect(blank?('  _  ')).to eq(false)
+    end
+
+    it 'works with booleans' do
+      expect(blank?(true)).to eq(false)
+      expect(blank?(false)).to eq(true)
+    end
+
+    it 'works with nil' do
+      expect(blank?(nil)).to eq(true)
+    end
+  end
+end

--- a/spec/amqp_mailer/amqp_mailer_spec.rb
+++ b/spec/amqp_mailer/amqp_mailer_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 require 'securerandom'
 require 'mail'
-require 'active_support'
-require 'active_support/core_ext'
 
 describe AmqpMailer do
   before(:each) do


### PR DESCRIPTION
We have both rails 4 and 5 projects. Dependency on activesupport was causing compatibility issues. We were only using it for `.present?` and `.blank?`. This PR adds a custom `blank?` method and removed activesupport as dependency.