### PR TITLE
Make DeliveryMethod instances respond to `settings`

### DIFF
--- a/lib/amqp_mailer/delivery_method.rb
+++ b/lib/amqp_mailer/delivery_method.rb
@@ -10,7 +10,10 @@ module AmqpMailer
 
     class MissingConfiguration < StandardError; end
 
+    attr_reader :settings
+
     def initialize(*)
+      @settings = {}
       raise MissingConfiguration, 'AMQP URL is missing' if blank?(AmqpMailer.configuration.amqp_url)
       raise MissingConfiguration, 'Notifications topic exchange is missing' if blank?(AmqpMailer.configuration.notifications_topic_exchange)
       raise MissingConfiguration, 'Sender Service ID is missing' if blank?(AmqpMailer.configuration.service_id)

--- a/spec/amqp_mailer/amqp_mailer/delivery_method_spec.rb
+++ b/spec/amqp_mailer/amqp_mailer/delivery_method_spec.rb
@@ -1,0 +1,15 @@
+require 'amqp_mailer/delivery_method'
+
+describe AmqpMailer::DeliveryMethod do
+  it 'it\'s instance responds to settings' do
+    AmqpMailer.configure do |config|
+      config.amqp_url = 'amqp://boggart'
+      config.notifications_topic_exchange = 'quidditch'
+      config.service_id = 'daily-prophet'
+    end
+
+    inst = AmqpMailer::DeliveryMethod.new
+
+    expect(inst.settings).to eq({})
+  end
+end

--- a/spec/amqp_mailer/amqp_mailer_spec.rb
+++ b/spec/amqp_mailer/amqp_mailer_spec.rb
@@ -4,8 +4,8 @@ require 'mail'
 
 describe AmqpMailer do
   before(:each) do
-    @verification_id = SecureRandom.uuid
-    allow(SecureRandom).to receive(:uuid).and_return(@verification_id)
+    @dummy_notification_id = SecureRandom.uuid
+    allow(SecureRandom).to receive(:uuid).and_return(@dummy_notification_id)
 
     AmqpMailer.configure do |config|
       config.amqp_url = 'amqp://boggart'
@@ -31,7 +31,7 @@ describe AmqpMailer do
         phone_number: '9999999999',
         service_id: 'daily-prophet',
         notification_type: 'email',
-        notification_id: @verification_id
+        notification_id: @dummy_notification_id
     }
 
     expect_any_instance_of(AmqpMailer::NotificationDispatcher).to receive(:perform).with(expected_payload)
@@ -56,7 +56,7 @@ describe AmqpMailer do
           phone_number: AmqpMailer::DeliveryMethod::DEFAULT_SIMPL_PHONE_NUMBER,
           service_id: 'daily-prophet',
           notification_type: 'email',
-          notification_id: @verification_id
+          notification_id: @dummy_notification_id
       }
 
       expect_any_instance_of(AmqpMailer::NotificationDispatcher).to receive(:perform).with(expected_payload)


### PR DESCRIPTION
`Mail::Message` expects `DeliveryMethod` to have a `settings` instance method. Without it, we were getting `NoMethodError`, and sidekiq was triggering the same job repeatedly. Since AmqpMailer's `DeliveryMethod` doesn't rely on any settings object, added a dummy settings method which returns empty hash.