### PR TITLE
Replace autoload with require

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amqp_mailer (0.1.0)
+    amqp_mailer (0.2.2)
       bunny (>= 2.6.3)
 
 GEM

--- a/lib/amqp_mailer.rb
+++ b/lib/amqp_mailer.rb
@@ -1,10 +1,9 @@
 require 'amqp_mailer/version'
+require 'amqp_mailer/delivery_method'
+require 'amqp_mailer/notification_dispatcher'
+require 'amqp_mailer/configuration'
 
 module AmqpMailer
-  autoload :DeliveryMethod, 'amqp_mailer/delivery_method'
-  autoload :NotificationDispatcher, 'amqp_mailer/notification_dispatcher'
-  autoload :Configuration, 'amqp_mailer/configuration'
-
   def self.configuration
     @configration ||= Configuration.new
   end

--- a/lib/amqp_mailer/version.rb
+++ b/lib/amqp_mailer/version.rb
@@ -1,3 +1,3 @@
 module AmqpMailer
-  VERSION = '0.1.0'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
`autoload` is not threadsafe and will be deprecated in ruby 3. Replacing it with `require`

- https://bugs.ruby-lang.org/issues/5653